### PR TITLE
Make `ethernet` optional

### DIFF
--- a/coordinator-example.yaml
+++ b/coordinator-example.yaml
@@ -8,6 +8,7 @@ packages:
     ref: main
     files:
       - packages/core.yaml
+      - packages/ethernet.yaml
       - packages/status_led.yaml
       - packages/i2c.yaml
       - packages/button_zigbee_reset.yaml

--- a/packages/core.yaml
+++ b/packages/core.yaml
@@ -19,7 +19,7 @@ esphome:
   comment: ${device_description}
   project:
     name: "syssi.esphome-zb-gw03"
-    version: 1.0.0
+    version: 2.0.0
   on_boot:
     priority: 600
     then:

--- a/packages/ethernet.yaml
+++ b/packages/ethernet.yaml
@@ -1,0 +1,7 @@
+ethernet:
+  type: LAN8720
+  mdc_pin: GPIO23
+  mdio_pin: GPIO18
+  clk_mode: GPIO17_OUT
+  phy_addr: 1
+  power_pin: GPIO16

--- a/packages/wifi.yaml
+++ b/packages/wifi.yaml
@@ -1,0 +1,3 @@
+wifi:
+  ssid: !secret wifi_ssid
+  password: !secret wifi_password

--- a/router-example.yaml
+++ b/router-example.yaml
@@ -8,6 +8,7 @@ packages:
     ref: main
     files:
       - packages/core.yaml
+      - packages/ethernet.yaml
       - packages/status_led.yaml
       - packages/button_pairing_mode.yaml
     refresh: 0s


### PR DESCRIPTION
In release 2.0.0 you can choose between `ethernet` or `wifi` by loading the dedicated package:

```
packages:
  zb-gw03:
    url: https://github.com/syssi/esphome-zb-gw03
    ref: main
    files:
      - packages/core.yaml
      - packages/ethernet.yaml

# vs

packages:
  zb-gw03:
    url: https://github.com/syssi/esphome-zb-gw03
    ref: main
    files:
      - packages/core.yaml
      - packages/wifi.yaml
```

This is a breaking change! To migrate from version 1.0.0 to version 2.0.0 you have to add the `packages/ethernet.yaml` to your YAML.