### PR TITLE
Invert green LED

### DIFF
--- a/packages/green_led.yaml
+++ b/packages/green_led.yaml
@@ -7,3 +7,4 @@ output:
   - platform: ledc
     pin: GPIO14
     id: output0
+    inverted: true


### PR DESCRIPTION
At startup, the green light is off.
To announce the correct state to any client’s frontend, (usually Home Assistant).