### PR TITLE
Remove redundant name substitution prefix from entity names

### DIFF
--- a/packages/button_pairing_mode.yaml
+++ b/packages/button_pairing_mode.yaml
@@ -3,7 +3,7 @@
 #
 # button:
 #   - platform: template
-#     name: "${name} Enable Pairing Mode"
+#     name: "Enable Pairing Mode"
 #     on_press:
 #       - switch.turn_on: download_mode
 #       - delay: 5s
@@ -12,7 +12,7 @@
 switch:
   - platform: template
     id: zigbee_pairing_mode
-    name: "${name} Toggle pairing mode"
+    name: "Toggle pairing mode"
     turn_on_action:
       - switch.turn_on: download_mode
       - delay: 5s
@@ -20,7 +20,7 @@ switch:
 
 binary_sensor:
   - platform: gpio
-    name: "${name} Enable Pairing Mode"
+    name: "Enable Pairing Mode"
     internal: true
     pin:
       number: GPIO34

--- a/packages/button_zigbee_reset.yaml
+++ b/packages/button_zigbee_reset.yaml
@@ -1,6 +1,6 @@
 binary_sensor:
   - platform: gpio
-    name: "${name} Zigbee Reset Button"
+    name: "Zigbee Reset Button"
     pin:
       number: GPIO34
       inverted: true

--- a/packages/core.yaml
+++ b/packages/core.yaml
@@ -16,6 +16,7 @@ substitutions:
 
 esphome:
   name: ${name}
+  friendly_name: ${name}
   comment: ${device_description}
   min_version: 2024.6.0
   project:

--- a/packages/core.yaml
+++ b/packages/core.yaml
@@ -58,11 +58,11 @@ stream_server:
 
 switch:
   - platform: restart
-    name: "${name} Restart"
+    name: "Restart"
 
   - platform: template
     id: zigbee_reset
-    name: "${name} Zigbee Reset"
+    name: "Zigbee Reset"
     turn_on_action:
       - switch.turn_on: zigbee_rst
       - delay: 10ms
@@ -72,7 +72,7 @@ switch:
   - platform: gpio
     id: zigbee_rst
     pin: GPIO13
-    name: "${name} Zigbee nRST"
+    name: "Zigbee nRST"
     inverted: true
     internal: true
     restore_mode: ALWAYS_OFF
@@ -81,6 +81,6 @@ switch:
   - platform: gpio
     id: download_mode
     pin: GPIO12
-    name: "${name} Zigbee Download Mode"
+    name: "Zigbee Download Mode"
     inverted: true
     restore_mode: ALWAYS_OFF

--- a/packages/green_led.yaml
+++ b/packages/green_led.yaml
@@ -1,6 +1,6 @@
 light:
   - platform: monochromatic
-    name: "${name} green led"
+    name: "green led"
     output: output0
 
 output:


### PR DESCRIPTION
ESPHome's `friendly_name` automatically prefixes all entity names, making the `${name}` substitution in entity name strings redundant.